### PR TITLE
Fix update not working on IPv6 IRC connections.

### DIFF
--- a/dlFilter.mrc
+++ b/dlFilter.mrc
@@ -199,13 +199,14 @@ dlFilter uses the following code from other people:
       Fix issue with autoget in mIRC v7.57 and below only doing autoget on first trust entry by resequencing existing trust entries to after the new one.
       Only save searchbot requests for 5 minutes instead of 24 hours (in case server is offline we don't want to requeue searchbot requests).
       Fix messages being copied to active window from other connections.
+      Fix issue with update not working on IPv6 connections.
 
 */
 
 ; Increase this when you have sufficient changes to justify a release
 ; When you want to trigger updates for existing users, change the version file.
 alias -l DLF.SetVersion {
-  %DLF.version = 2.11
+  %DLF.version = 2.12
   return %DLF.version
 }
 

--- a/dlFilter.mrc
+++ b/dlFilter.mrc
@@ -5095,8 +5095,8 @@ alias -l DLF.Socket.Open {
   %hostport = $+(%host,:,$port)
 
   if ($sock(%socket)) sockclose %socket
-  var %flag
-  if (%protocol == https) %flag = -e
+  var %flag -46
+  if (%protocol == https) %flag = %flag $+ e
   sockopen %flag %socket %host %port
   sockmark %socket Opening %host %path %dialog %dialogid
 }

--- a/dlFilter.version
+++ b/dlFilter.version
@@ -1,3 +1,3 @@
 ;id|dlf-ver|min-mirc-ver|version improvements
-dlFilter|2.11|7.44|Lots of minor improvements and fixes.
+dlFilter|2.12|7.44|Lots of minor improvements and fixes.
 dlFilter.beta|2.08|7.44|You may need to download manually.


### PR DESCRIPTION
Workaround for mIRC not doing DNS lookups for IPv4 when IRC connection is IPv6. D'oh!